### PR TITLE
Fix README style filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ latexmk -pdf
 ## File Structure
 - `paper.tex` : Main TeX file
 - `IEEEtran.cls` : IEEE paper class file
-- `IEEEtran.bst` : IEEE bibliography style
+- `IEEEtranS.bst` : IEEE bibliography style
 - `out/` : Output directory (auto-generated)
 - `.latexmkrc` : Configuration file for latexmk
 


### PR DESCRIPTION
## Summary
- correct the bibliography style file name in the README

## Testing
- `lacheck paper.tex` *(fails: command not found)*
- `latexmk -pdf paper.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a78cee6a48322b0d5da59bee0df00