### PR TITLE
Fix GitHub Actions TeX Live setup

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -14,12 +14,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install TeX Live
-        uses: aminya/setup-texlive@v2
-        with:
-          packages: >-
-            scheme-full
-            latexmk
-            lacheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-full latexmk lacheck
 
       - name: Lint LaTeX source
         run: |

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install TeX Live
-        uses: latex-actions/setup-texlive@v2
+        uses: aminya/setup-texlive@v2
         with:
           packages: >-
             scheme-full

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -16,11 +16,7 @@ jobs:
       - name: Set up TeX Live
         uses: teatimeguest/setup-texlive-action@v3
         with:
-          packages: >-
-            scheme-medium
-            latexmk
-            latexindent
-            lacheck
+          packages: scheme-full
 
       - name: Lint LaTeX source
         run: |

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -13,10 +13,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up TeX Live
-        uses: teatimeguest/setup-texlive-action@v3
+      - name: Install TeX Live
+        uses: latex-actions/setup-texlive@v2
         with:
-          packages: scheme-full
+          packages: >-
+            scheme-full
+            latexmk
+            lacheck
 
       - name: Lint LaTeX source
         run: |


### PR DESCRIPTION
## Summary
- use `scheme-full` in GitHub Actions workflow to ensure all TeX Live packages are available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7acfd1ac8322ac8a563b3f9b8054